### PR TITLE
chore: Version packages

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,5 +15,5 @@
     "@aligntrue/testkit": "0.1.1-alpha.3",
     "@aligntrue/ui": "0.1.1-alpha.3"
   },
-  "changesets": ["alpha-3-release"]
+  "changesets": ["alpha-4-release"]
 }

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aligntrue/docs
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- Updated dependencies [97e54ee]
+  - @aligntrue/ui@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/docs",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/aligntrue/CHANGELOG.md
+++ b/packages/aligntrue/CHANGELOG.md
@@ -1,5 +1,13 @@
 # aligntrue
 
+## 0.1.0-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/cli@0.1.1-alpha.4
+
 ## 0.1.0-alpha.3
 
 ### Patch Changes

--- a/packages/aligntrue/package.json
+++ b/packages/aligntrue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aligntrue",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "AlignTrue CLI shim - AI alignment rules for developers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @aligntrue/cli
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+  - @aligntrue/core@0.1.1-alpha.4
+  - @aligntrue/exporters@0.1.1-alpha.4
+  - @aligntrue/markdown-parser@0.1.1-alpha.4
+  - @aligntrue/sources@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/cli",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "bin": {
     "aligntrue": "./dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @aligntrue/core
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+  - @aligntrue/exporters@0.1.1-alpha.4
+  - @aligntrue/markdown-parser@0.1.1-alpha.4
+  - @aligntrue/file-utils@0.1.1-alpha.4
+  - @aligntrue/plugin-contracts@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/core",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/exporters/CHANGELOG.md
+++ b/packages/exporters/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aligntrue/exporters
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+  - @aligntrue/core@0.1.1-alpha.4
+  - @aligntrue/file-utils@0.1.1-alpha.4
+  - @aligntrue/plugin-contracts@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/exporters/package.json
+++ b/packages/exporters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/exporters",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/file-utils/CHANGELOG.md
+++ b/packages/file-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aligntrue/file-utils
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/file-utils/package.json
+++ b/packages/file-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/file-utils",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/markdown-parser/CHANGELOG.md
+++ b/packages/markdown-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aligntrue/markdown-parser
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+
 ## Unreleased
 
 ### Security

--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/markdown-parser",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-contracts/CHANGELOG.md
+++ b/packages/plugin-contracts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aligntrue/plugin-contracts
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/plugin-contracts/package.json
+++ b/packages/plugin-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/plugin-contracts",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aligntrue/schema
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/schema",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sources/CHANGELOG.md
+++ b/packages/sources/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @aligntrue/sources
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+  - @aligntrue/core@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/sources",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/testkit/CHANGELOG.md
+++ b/packages/testkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aligntrue/testkit
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+- Updated dependencies [97e54ee]
+  - @aligntrue/schema@0.1.1-alpha.4
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/testkit",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "description": "Conformance testkit for Align Spec v1 implementations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aligntrue/ui
 
+## 0.1.1-alpha.4
+
+### Patch Changes
+
+- 97e54ee: Post-alpha.3 improvements: License fields added to all packages, test fixes, Windows compatibility improvements, and continued sections format refinements.
+
 ## 0.1.1-alpha.3
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligntrue/ui",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
This PR updates package versions and changelogs for the alpha.4 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps all workspace packages to alpha.4 and updates changelogs and `.changeset/pre.json` for the alpha-4 release.
> 
> - **Release: alpha.4**
>   - Version bump across monorepo packages (`@aligntrue/*`, `aligntrue`).
>   - Changelogs updated with post-alpha.3 patch notes and dependency updates.
>   - `apps/docs` updated to depend on `@aligntrue/ui@0.1.1-alpha.4`.
>   - `.changeset/pre.json` switches changeset tag to `"alpha-4-release"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a455e9bcd2176608eefa5ae657a0854575680450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->