### PR TITLE
Fix pnpm pre-cli issues and pass CI

### DIFF
--- a/packages/cli/tests/commands/backup.test.ts
+++ b/packages/cli/tests/commands/backup.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { backupCommand } from "../../src/commands/backup";
 import { BackupManager } from "@aligntrue/core";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 // Mock clack
@@ -85,6 +85,9 @@ describe("backup command", () => {
   describe("restore subcommand", () => {
     it("should restore most recent backup", async () => {
       const _backup = BackupManager.createBackup({ cwd: testDir });
+
+      // Small delay to ensure different timestamps (backups use milliseconds)
+      await new Promise((resolve) => setTimeout(resolve, 2));
 
       // Modify files
       writeFileSync(join(aligntrueDir, "config.yaml"), "mode: team", "utf-8");

--- a/packages/core/src/sync/file-operations.ts
+++ b/packages/core/src/sync/file-operations.ts
@@ -2,12 +2,14 @@
  * File operations for sync with backup support
  */
 
-import { readFile, writeFile, copyFile, existsSync } from "fs";
+import { readFile, writeFile, copyFile, existsSync, mkdir } from "fs";
 import { promisify } from "util";
+import { dirname } from "path";
 
 const readFileAsync = promisify(readFile);
 const writeFileAsync = promisify(writeFile);
 const copyFileAsync = promisify(copyFile);
+const mkdirAsync = promisify(mkdir);
 
 export interface BackupOptions {
   enabled: boolean;
@@ -29,6 +31,10 @@ export async function writeFileWithBackup(
   content: string,
   options: BackupOptions,
 ): Promise<BackupResult> {
+  // Ensure parent directory exists
+  const dir = dirname(filePath);
+  await mkdirAsync(dir, { recursive: true });
+
   if (!options.enabled) {
     await writeFileAsync(filePath, content, "utf-8");
     return { backed_up: false };

--- a/packages/core/tests/backup/manager.test.ts
+++ b/packages/core/tests/backup/manager.test.ts
@@ -140,9 +140,12 @@ describe("BackupManager", () => {
   });
 
   describe("restoreBackup", () => {
-    it("should restore most recent backup when no timestamp provided", () => {
+    it("should restore most recent backup when no timestamp provided", async () => {
       // Create initial backup
-      BackupManager.createBackup({ cwd: testDir });
+      const backup1 = BackupManager.createBackup({ cwd: testDir });
+
+      // Small delay to ensure different timestamps (backups use milliseconds)
+      await new Promise((resolve) => setTimeout(resolve, 2));
 
       // Modify files
       writeFileSync(
@@ -153,6 +156,9 @@ describe("BackupManager", () => {
 
       // Restore
       const restored = BackupManager.restoreBackup({ cwd: testDir });
+
+      // Should have restored from the first backup (not the temp backup created during restore)
+      expect(restored.timestamp).toBe(backup1.timestamp);
 
       // Check files are restored
       const content = readFileSync(join(aligntrueDir, "config.yaml"), "utf-8");


### PR DESCRIPTION
Adds directory creation to `writeFileWithBackup` and resolves backup test timing issues.

The backup tests were failing because the `restoreBackup` method creates a temporary backup before restoring. When the original backup and this temporary backup were created too close in time, their timestamps could be very similar, leading to `listBackups` returning them in an unexpected order. Adding a small delay ensures distinct timestamps and correct backup selection during restore.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c4ae94d-9744-433e-980f-248bb1051b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c4ae94d-9744-433e-980f-248bb1051b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

